### PR TITLE
Guard the Linux build against bad snap template extraction

### DIFF
--- a/build-all-linux.sh
+++ b/build-all-linux.sh
@@ -10,7 +10,18 @@ mkdir ./dist-bin
 npm run download-bundle
 npm run unpack-bundle -- ./bundle.json
 npm run arm-wayland
+# Builds made before patches/app-builder-lib+26.15.3.patch poisoned the
+# extracted snap-template cache (the inner tar left unextracted); on a cache
+# hit the patched extraction never runs, so clear it to force a redo.
+EB_CACHE="${ELECTRON_BUILDER_CACHE:-$HOME/.cache/electron-builder}"
+rm -rf "$EB_CACHE"/snap-template-*
 npm run dist
+# A bad template extraction ships a snap without desktop-init.sh that fails
+# at launch for every user (all snaps 2.6.2-2.6.7 had this) — fail the build.
+if ! ls "$EB_CACHE"/snap-template-*/*/desktop-init.sh >/dev/null 2>&1; then
+  echo "ERROR: snap template was not extracted correctly; the built snap would be missing desktop-init.sh and fail to launch" >&2
+  exit 1
+fi
 sh ./build-targz.sh
 sh ./build-flatpak.sh
 npm run rename-packages

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimiri-notes",
   "productName": "Mimiri Notes",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "main": "main.js",
   "scripts": {
     "build": "tsc",

--- a/src/base-version.ts
+++ b/src/base-version.ts
@@ -5,7 +5,7 @@ export interface BaseVersion {
 }
 
 export const baseVersion = '2.6.4';
-export const hostVersion = '2.6.7';
+export const hostVersion = '2.6.8';
 export const releaseDate = '2026-07-07T07:53:09.702Z';
 
 export default {


### PR DESCRIPTION
## Why the published 2.6.7 snap is still broken

The 2.6.7 snap on update.mimiri.io still ships the unextracted `snap-template-electron-4.0-2-amd64.tar` (no `desktop-init.sh` — fails at launch), even though the build included #6. Cause: the **extracted-template cache on the build machine is poisoned** by pre-patch builds. `downloadBuilderToolset` skips extraction entirely on a cache hit, so the patched code never ran. (This was the ⚠️ caveat in #6 — the cache clear has to happen once on each build machine.)

## What this PR does

In `build-all-linux.sh`:

1. **Clears the template cache before `npm run dist`** (`rm -rf $EB_CACHE/snap-template-*`) — makes the fix take effect regardless of machine state, forever.
2. **Fails the build if the extracted template lacks `desktop-init.sh`** — so this class of bug (poisoned cache, patch silently dropped by a future electron-builder upgrade, upstream regression) can never ship silently again.

arm64 snaps are unaffected — only x64/armv7l use the template path (`coreLegacy.js` gates on `Arch.x64 || Arch.armv7l`); arm64 goes through snapcraft.

## Verification

- Guard passes on a good cache and fails on a simulated poisoned one.
- From-scratch rebuild of the 2.6.7 snap on this machine (cache cleared → `npm run build` → electron-builder): snap contains `desktop-init.sh`, no stray tar, and passes the full mimiri-e2e suite under strict confinement (10/10 incl. export/import portal dialogs and the version seam).

**After merging: rebuild and re-publish the 2.6.7 Linux snap** (or bump to 2.6.8) — the guard handles the cache clear automatically. The mimiri-e2e CI snap job will go green once the fixed snap is on the feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)