### PR TITLE
Fix snap guard failing the arm64 build

### DIFF
--- a/build-all-linux.sh
+++ b/build-all-linux.sh
@@ -16,11 +16,27 @@ npm run arm-wayland
 EB_CACHE="${ELECTRON_BUILDER_CACHE:-$HOME/.cache/electron-builder}"
 rm -rf "$EB_CACHE"/snap-template-*
 npm run dist
-# A bad template extraction ships a snap without desktop-init.sh that fails
-# at launch for every user (all snaps 2.6.2-2.6.7 had this) — fail the build.
-if ! ls "$EB_CACHE"/snap-template-*/*/desktop-init.sh >/dev/null 2>&1; then
-  echo "ERROR: snap template was not extracted correctly; the built snap would be missing desktop-init.sh and fail to launch" >&2
-  exit 1
+# A snap without desktop-init.sh fails at launch for every user (all x64
+# snaps 2.6.2-2.6.7 shipped like this) — fail the build. Both build paths
+# stage the script to the snap root (template on x64/armv7l, snapcraft on
+# arm64), so inspect the artifact itself when unsquashfs is available. The
+# extracted-template cache is only a fallback proxy, and only meaningful on
+# the template arches — arm64 never creates it.
+SNAP_FILE=$(ls dist/mimiri-notes_*.snap 2>/dev/null | head -n 1)
+if command -v unsquashfs >/dev/null 2>&1 && [ -n "$SNAP_FILE" ]; then
+  if ! unsquashfs -l "$SNAP_FILE" 2>/dev/null | grep -q 'desktop-init\.sh'; then
+    echo "ERROR: $SNAP_FILE is missing desktop-init.sh and would fail to launch" >&2
+    exit 1
+  fi
+else
+  case "$(uname -m)" in
+    x86_64 | armv7l)
+      if ! ls "$EB_CACHE"/snap-template-*/*/desktop-init.sh >/dev/null 2>&1; then
+        echo "ERROR: snap template was not extracted correctly; the built snap would be missing desktop-init.sh and fail to launch" >&2
+        exit 1
+      fi
+      ;;
+  esac
 fi
 sh ./build-targz.sh
 sh ./build-flatpak.sh


### PR DESCRIPTION
The guard from #7 checked for the extracted snap-template cache unconditionally — but only x64/armv7l use electron-builder's template path. arm64 builds via snapcraft, never create that cache, and so failed the guard even though the snap was fine.

The guard now verifies the real invariant on the artifact itself: `unsquashfs -l dist/mimiri-notes_*.snap` must contain `desktop-init.sh` (both build paths stage it to the snap root — confirmed on the published snapcraft-built 2.6.4 arm64 snap). The cache check remains only as a fallback for the template arches when `unsquashfs` isn't installed; on arm64 without unsquashfs the guard no-ops, which is safe since arm64 was never affected by the extraction bug.

Verified against real artifacts:
- ✅ passes: fixed 2.6.8 amd64 snap, locally rebuilt 2.6.7 amd64 snap, published 2.6.4 arm64 snap
- ❌ fails (correctly): the broken published 2.6.7 amd64 snap

If `unsquashfs` is missing on the build machines, `sudo apt install squashfs-tools` gets the stronger artifact check everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)