### PR TITLE
Fix arm64 AppImage never reaching dist-bin

### DIFF
--- a/scripts/rename-packages.mjs
+++ b/scripts/rename-packages.mjs
@@ -8,14 +8,25 @@ const run = async () => {
 		const packageJson = JSON.parse(readFileSync('./package.json'));
 
 		if (process.platform === 'linux') {
+			// A missed artifact must fail the build; by default shelljs only logs
+			// (the 2.6.8 arm64 AppImage silently never made it into dist-bin).
+			shell.config.fatal = true;
+
 			let arch = 'amd64';
 			if (process.arch === 'arm64') {
 				arch = 'arm64';
 			}
 
+			// electron-builder appends the arch to the AppImage name on arm64
+			// (Mimiri Notes-2.6.8-arm64.AppImage) but not on x64.
+			const appImageSrc =
+				process.arch === 'arm64'
+					? `./dist/Mimiri Notes-${packageJson.version}-arm64.AppImage`
+					: `./dist/Mimiri Notes-${packageJson.version}.AppImage`;
+
 			shell.mv('./dist/mimiri-notes.tar.gz', `./dist-bin/mimiri-notes_${packageJson.version}_${arch}.tar.gz`);
 			shell.mv(`./dist/mimiri-notes_${packageJson.version}_${arch}.snap`, `./dist-bin/mimiri-notes_${packageJson.version}_${arch}.snap`);
-			shell.mv(`./dist/Mimiri Notes-${packageJson.version}.AppImage`, `./dist-bin/mimiri-notes_${packageJson.version}_${arch}.AppImage`);
+			shell.mv(appImageSrc, `./dist-bin/mimiri-notes_${packageJson.version}_${arch}.AppImage`);
 			shell.mv('./mimiri-flatpak/io.mimiri.notes.flatpak', `./dist-bin/io.mimiri.notes_${packageJson.version}_${arch}.flatpak`);
 
 			writeFileSync('./artifacts.json', JSON.stringify([


### PR DESCRIPTION
## Problem

The new arm64 e2e CI jobs (innonova/mimiri-e2e#2) caught that `mimiri-notes_2.6.8_arm64.AppImage` is a **404 on update.mimiri.io** even though latest.json lists it — the other three arm64 formats are fine.

Root cause: electron-builder names the AppImage with an arch suffix on arm64 (`Mimiri Notes-2.6.8-arm64.AppImage` — visible in the raspi build log) but not on x64. `rename-packages.mjs` moves the un-suffixed name, and shelljs `mv` only *logs* a missing source without failing, so the script still printed "Package renaming completed successfully" while the arm64 AppImage never entered `dist-bin`/`artifacts.json`.

## Fix

- Use the arch-suffixed source name on arm64.
- `shell.config.fatal = true` for the Linux block, so any future missed artifact throws → caught → `process.exit(1)` — a silent miss can't recur.

Verified: fatal mode throws on a missing source (script exits 1), syntax checked; the x64 path is unchanged.

## After merging

The already-built `dist/Mimiri Notes-2.6.8-arm64.AppImage` should still be on the raspi — it just needs renaming to `mimiri-notes_2.6.8_arm64.AppImage` and uploading (no rebuild required). The failing e2e arm64 appimage job can then be re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)