### PR TITLE
Clear HTTP cache when activating a bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimiri-notes",
   "productName": "Mimiri Notes",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "main": "main.js",
   "scripts": {
     "build": "tsc",

--- a/src/base-version.ts
+++ b/src/base-version.ts
@@ -5,7 +5,7 @@ export interface BaseVersion {
 }
 
 export const baseVersion = '2.6.5';
-export const hostVersion = '2.6.9';
+export const hostVersion = '2.6.10';
 export const releaseDate = '2026-07-10T16:10:27.990Z';
 
 export default {

--- a/src/managers/bundle-manager.ts
+++ b/src/managers/bundle-manager.ts
@@ -330,6 +330,15 @@ export class BundleManager {
     }
     this.lastActivate = Date.now();
     this.activePath = Path.join(pathInfo.bundles!, this.config.activeVersion);
+    // Drop cached responses from the previous bundle before navigating.
+    // Without this, a navigation shortly after activation (e.g. the watch
+    // dog reloading a slow-booting window) can be served the previous
+    // bundle's index.html from the HTTP cache, reviving the old version.
+    try {
+      await mainWindow.webContents.session.clearCache();
+    } catch {
+      // never let cache maintenance block activation
+    }
     mainWindow.reload();
   }
 


### PR DESCRIPTION
A navigation shortly after bundle activation — typically the watch dog reloading a window that boots slowly on a weak machine — could be served the **previous** bundle's `index.html` from the HTTP cache, reviving the old version until the cache revalidated. The watch dog fires `loadURL()` when the renderer hasn't answered for 6s, which a post-activation boot can exceed on slow hardware; that navigation then hit the cache.

Fix: clear the session cache in `BundleManager.activate()` before the reload, so every subsequent navigation sees the new bundle. Wrapped in try/catch so cache maintenance can never block activation.

Found by the bundle-update e2e test running on a slow Windows VM (innonova/mimiri-e2e#4 has the full analysis; the e2e currently works around it by clearing the cache via CDP before activating — that workaround can be removed once this ships).

Bumps version to 2.6.10 (update-bundle re-run; base bundle stays 2.6.5).

Note: merging to main triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)