### PR TITLE
Watch dog grace period around bundle activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimiri-notes",
   "productName": "Mimiri Notes",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "main": "main.js",
   "scripts": {
     "build": "tsc",

--- a/src/base-version.ts
+++ b/src/base-version.ts
@@ -5,7 +5,7 @@ export interface BaseVersion {
 }
 
 export const baseVersion = '2.6.6';
-export const hostVersion = '2.6.11';
+export const hostVersion = '2.6.12';
 export const releaseDate = '2026-07-10T18:53:48.141Z';
 
 export default {

--- a/src/managers/mimer-ipc-client.ts
+++ b/src/managers/mimer-ipc-client.ts
@@ -129,11 +129,17 @@ export class MimerIpcClient {
 
     ipcMain.on("bundle-use", (e, version, noActivate) => {
       if (!this.validateSender(e.senderFrame)) return;
+      // Activation reloads the window; give the new bundle time to boot on
+      // slow machines before the watch dog considers correcting course.
+      if (!noActivate) {
+        this.watchDog.grace(30_000);
+      }
       return this.bundleManager.use(version, this.mainWindow!, noActivate);
     });
 
     ipcMain.on("bundle-activate", (e) => {
       if (!this.validateSender(e.senderFrame)) return;
+      this.watchDog.grace(30_000);
       return this.bundleManager.activate(this.mainWindow!);
     });
 

--- a/src/managers/watch-dog.ts
+++ b/src/managers/watch-dog.ts
@@ -6,6 +6,7 @@ export class WatchDog {
   private reloadCount: number = 0;
   private lastOk: number = 0;
   private startTime: number = 0;
+  private graceUntil: number = 0;
   private interval?: NodeJS.Timeout;
 
   init(startUrl: string, mainWindow: BrowserWindow): void {
@@ -42,8 +43,24 @@ export class WatchDog {
     }
   }
 
+  /**
+   * Suppresses reload/loadURL corrections for a while, keeping only the
+   * renderer pings. Used around deliberate navigations (bundle activation):
+   * a slow machine can take longer than the stale threshold to boot the new
+   * bundle, and a watch dog navigation fired mid-boot interrupts it — the
+   * doubled boot can crash the renderer and leave a dead page.
+   */
+  grace(ms: number): void {
+    this.graceUntil = Date.now() + ms;
+  }
+
   private check(): void {
     if (!this.mainWindow || !this.startUrl) {
+      return;
+    }
+
+    if (Date.now() < this.graceUntil) {
+      this.mainWindow.webContents.send("watch-dog-check");
       return;
     }
 


### PR DESCRIPTION
The new bundle-repair e2e (innonova/mimiri-e2e#6) failed on the mac/win/snap CI legs against 2.6.11 while all Linux legs passed — and the instrumented reproduction on the Windows VM showed why: disk state and config were perfect, the repaired bundle loaded, but **TextMate initialized twice followed by a Vue `nextSibling` crash and an empty `#app`**. Two boots in one window = the watch dog fired `loadURL` mid-boot.

On slow machines the post-activation boot exceeds the watch dog's 6s stale threshold; the mid-boot navigation interrupts and doubles the boot, which can crash the renderer and leave a dead page that never answers the watch dog again (it goes passive after 18s — no recovery). 2.6.10's `clearCache` fixed the *stale content* flavor of watchdog-vs-activation; this is the remaining *interrupted boot* flavor, and it affects real users on slow machines updating bundles, independent of the tests.

Fix: `bundle-use`/`bundle-activate` grant the watch dog a **30s grace period** during which it keeps pinging the renderer but never reloads/loadURLs. After expiry the stale-reset path makes it passive-then-recovering rather than immediately correcting.

Verified: bundle-update + bundle-repair specs pass against a local 2.6.12 targz build; the mac/win/snap proof comes from CI once this releases (the e2e gate moves to ≥ 2.6.12 in the companion PR).

Bumps version to 2.6.12. Note: merging to main triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)