### PR TITLE
Detect flathub and snap-store installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimiri-notes",
   "productName": "Mimiri Notes",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "main": "main.js",
   "scripts": {
     "build": "tsc",

--- a/preload.js
+++ b/preload.js
@@ -12,12 +12,14 @@ function isAppImage() {
 	return process.platform === 'linux' && !!process.env.APPIMAGE;
 }
 
+// Store detection happens in the main process (sandboxed preloads cannot
+// read /.flatpak-info) and arrives via the mimiri-info argument.
 function isFlatHub() {
-	return false;
+	return mimiriInfo?.isFlatHub ?? false;
 }
 
 function isSnapStore() {
-	return false;
+	return mimiriInfo?.isSnapStore ?? false;
 }
 
 function isTarGz() {

--- a/src/base-version.ts
+++ b/src/base-version.ts
@@ -5,7 +5,7 @@ export interface BaseVersion {
 }
 
 export const baseVersion = '2.6.6';
-export const hostVersion = '2.6.12';
+export const hostVersion = '2.6.13';
 export const releaseDate = '2026-07-10T18:53:48.141Z';
 
 export default {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,9 @@ import {
   updateUrlOverride,
   updateKeyOverride,
   userDataDirOverride,
+  fakeStoreOverride,
+  detectFlatHub,
+  detectSnapStore,
 } from "./runtime-config";
 import { baseVersion, hostVersion } from "./base-version";
 
@@ -82,6 +85,16 @@ if (!gotTheLock) {
       blogApiUrl: blogApiUrlOverride,
       updateUrl: updateUrlOverride,
       updateKey: updateKeyOverride,
+      // Detected in the main process — sandboxed preloads cannot read
+      // /.flatpak-info. The fake-store override is test-mode only.
+      isFlatHub:
+        testMode && fakeStoreOverride
+          ? fakeStoreOverride === "flathub"
+          : detectFlatHub(),
+      isSnapStore:
+        testMode && fakeStoreOverride
+          ? fakeStoreOverride === "snapstore"
+          : detectSnapStore(),
     };
     mainWindow = new BrowserWindow({
       width: 800,

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { readFileSync } from "node:fs";
 
 const userDataDirPrefix = "--user-data-dir=";
 const userDataDirArg = process.argv.find((arg) =>
@@ -18,6 +19,41 @@ export const updateUrlOverride: string | undefined =
 
 export const updateKeyOverride: string | undefined =
   process.env.MIMIRI_UPDATE_KEY || undefined;
+
+/** Test-mode override for store detection: "flathub" | "snapstore". */
+export const fakeStoreOverride: string | undefined =
+  process.env.MIMIRI_FAKE_STORE || undefined;
+
+/**
+ * Whether this install came from flathub, as opposed to a directly
+ * downloaded .flatpak bundle. Flathub enforces publishing on the `stable`
+ * branch, while our own bundles are built on `master`; the running
+ * instance's branch is in /.flatpak-info (readable inside the sandbox).
+ */
+export function detectFlatHub(): boolean {
+  if (process.env.container !== "flatpak") {
+    return false;
+  }
+  try {
+    const info = readFileSync("/.flatpak-info", "utf-8");
+    const match = /^branch=(.*)$/m.exec(info);
+    return match ? match[1].trim() === "stable" : false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether this install came from the snap store, as opposed to a directly
+ * downloaded .snap installed with --dangerous. snapd assigns numeric
+ * revisions to store installs and x-prefixed ones (x1, x2, ...) to
+ * unasserted local installs.
+ */
+export function detectSnapStore(): boolean {
+  return (
+    !!process.env.SNAP && /^[0-9]+$/.test(process.env.SNAP_REVISION ?? "")
+  );
+}
 
 export const userDataDirOverride: string | undefined = userDataDirArg
   ? path.resolve(userDataDirArg.substring(userDataDirPrefix.length))


### PR DESCRIPTION
`isFlatHub()`/`isSnapStore()` were hardcoded `false`, so store installs were indistinguishable from sideloads — `isHostUpdateManaged` never applied on Linux, and flathub/snap-store users were offered **manual download links** for host updates instead of "your store will deliver it".

## Detection (verified empirically on real installs)
- **flathub**: flathub enforces publishing on the `stable` branch while our direct bundles build on `master`; the running instance's branch is in `/.flatpak-info`. Read in the **main process** (sandboxed preloads can't read files) and passed to the preload via the existing mimiri-info argument. *Caveat: convention-based — if a direct bundle ever ships on the `stable` branch this breaks; a baked `--env=` marker in the flathub manifest would make it explicit (the manifest repo is under our control).*
- **snap store**: snapd assigns numeric revisions to store installs and `x`-prefixed ones (`x1`, `x2`…) to `--dangerous` sideloads — `SNAP_REVISION` regex. (An *asserted* sideload keeps its numeric store revision, but those refresh from the store anyway, so classifying them as store-managed is correct for update purposes.)
- **`MIMIRI_FAKE_STORE=flathub|snapstore`** (test-mode only) lets the e2e suite exercise the store-managed presentation, since test installs are always sideloads.

## Companion changes
- mimiri-client (canary-markdown → 2.6.7): the store-managed `check()` state was unreachable (the managed path never set `latestVersion`, so the existing store notice in Update.vue was dead code); now Linux store installs surface "a newer app is required, your store delivers it" without a download link, plus testids.
- mimiri-e2e: `update-store-managed.spec.ts` asserts all three presentations (flathub / snap store via the fake seam, manual link for direct installs — the latter also validating real negative detection on the sideloaded flatpak/snap CI legs).

Verified with a local 2.6.13 + 2.6.7 build: all three presentation cases pass; bundle-update regression passes.

**Release sequencing**: publish client 2.6.7 to canary first, then re-run `npm run update-bundle` here before merging (base bundle must include the client-side change). Merging to main triggers the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)