### PR TITLE
Add MIMIRI_USE_DEV_API test-mode toggle

### DIFF
--- a/bundle-info.json
+++ b/bundle-info.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://update.mimiri.io/2024101797F6C918.2.6.6.json",
-  "hash": "7ad7bc923ef0ddaf387e4e23ebfaadb81fb0eecffe4477061cff8f2faca089d4"
+  "url": "https://update.mimiri.io/2024101797F6C918.2.6.8.json",
+  "hash": "28e709927e16b8d11be61c25423d09c7073e08ee5952d2e75b92807dce255599"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimiri-notes",
   "productName": "Mimiri Notes",
-  "version": "2.6.13",
+  "version": "2.6.14",
   "main": "main.js",
   "scripts": {
     "build": "tsc",

--- a/preload.js
+++ b/preload.js
@@ -50,6 +50,7 @@ if (mimiriInfo?.testMode) {
 			channel: mimiriInfo.channel,
 			platform: mimiriInfo.platform,
 			apiUrl: mimiriInfo.apiUrl,
+			useDevApi: mimiriInfo.useDevApi,
 			blogApiUrl: mimiriInfo.blogApiUrl,
 			updateUrl: mimiriInfo.updateUrl,
 			updateKey: mimiriInfo.updateKey,

--- a/src/base-version.ts
+++ b/src/base-version.ts
@@ -4,9 +4,9 @@ export interface BaseVersion {
 	releaseDate: string;
 }
 
-export const baseVersion = '2.6.6';
-export const hostVersion = '2.6.13';
-export const releaseDate = '2026-07-10T18:53:48.141Z';
+export const baseVersion = '2.6.8';
+export const hostVersion = '2.6.14';
+export const releaseDate = '2026-07-11T18:08:40.621Z';
 
 export default {
 	baseVersion,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { LogManager } from "./managers/log-manager";
 import {
   testMode,
   apiUrlOverride,
+  useDevApi,
   blogApiUrlOverride,
   updateUrlOverride,
   updateKeyOverride,
@@ -82,6 +83,7 @@ if (!gotTheLock) {
       platform: process.platform,
       testMode,
       apiUrl: apiUrlOverride,
+      useDevApi,
       blogApiUrl: blogApiUrlOverride,
       updateUrl: updateUrlOverride,
       updateKey: updateKeyOverride,

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -11,6 +11,14 @@ export const testMode: boolean = process.env.APP_TEST_MODE === "1";
 export const apiUrlOverride: string | undefined =
   process.env.MIMIRI_API_URL || undefined;
 
+/**
+ * Test-mode toggle: make the renderer use its compiled-in dev API host and
+ * dev server key pair instead of the production ones. A boolean toggle
+ * between baked-in key pairs on purpose — accepting an arbitrary key from
+ * the environment would let anyone who controls the env re-key the client.
+ */
+export const useDevApi: boolean = process.env.MIMIRI_USE_DEV_API === "1";
+
 export const blogApiUrlOverride: string | undefined =
   process.env.MIMIRI_BLOG_API_URL || undefined;
 


### PR DESCRIPTION
Shell side of the dev-API toggle: `MIMIRI_USE_DEV_API=1` → `mimiriInfo.useDevApi` → exposed on `mimiriTestInfo` (test mode only). The renderer (innonova/mimiri-client#46) uses it to switch to the compiled-in dev host + dev server key pair.

Deliberately a boolean selecting baked-in pairs, not an injectable key — an arbitrary `MIMIRI_API_KEY` env override would let anyone controlling the environment re-key a test-mode client.

Based on `store-detection` (retargets when that merges). Verified end-to-end with a locally built shell: mimiri-e2e `staging-sync.spec.ts` runs the full account-creation/sync/deletion loop against dev-api, green 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)